### PR TITLE
Use labels for acronym input checkboxes

### DIFF
--- a/eth/acronyms/index.html
+++ b/eth/acronyms/index.html
@@ -63,16 +63,16 @@
  
         Apply filters: &nbsp;
         <span class="avoidwrap"> 
-          <input type="checkbox" id="checkbox-ca" onchange="textInputUpdate()"> Computer Architecture  &nbsp;&nbsp; 
+          <input type="checkbox" id="checkbox-ca" onchange="textInputUpdate()"><label for="checkbox-ca">Computer Architecture</label>  &nbsp;&nbsp; 
         </span>
         <span class="avoidwrap"> 
-          <input type="checkbox" id="checkbox-cn" onchange="textInputUpdate()"> Computer Networks   &nbsp;&nbsp;
+          <input type="checkbox" id="checkbox-cn" onchange="textInputUpdate()"><label for="checkbox-cn">Computer Networks</label>  &nbsp;&nbsp;
         </span>
         <span class="avoidwrap"> 
-          <input type="checkbox" id="checkbox-infsek" onchange="textInputUpdate()"> Information Security   &nbsp;&nbsp;
+          <input type="checkbox" id="checkbox-infsek" onchange="textInputUpdate()"><label for="checkbox-infsek">Information Security</label>  &nbsp;&nbsp;
         </span>
         <span class="avoidwrap">  
-          <input type="checkbox" id="checkbox-ml" onchange="textInputUpdate()"> Machine Learning   &nbsp;&nbsp;
+          <input type="checkbox" id="checkbox-ml" onchange="textInputUpdate()"><label for="checkbox-ml">Machine Learning</label>  &nbsp;&nbsp;
         </span>
         <p class="right"><a class="text" href="description.html">about the data</a></p>
         <hr class="first">


### PR DESCRIPTION
This improves accessability, because screenreaders can associate the checkbox directly with the description.
It also makes it easier to tap the checkbox, since the clickable area extends to the label text.